### PR TITLE
Support mail button

### DIFF
--- a/features/issues/components/issue-list/issue-list.module.scss
+++ b/features/issues/components/issue-list/issue-list.module.scss
@@ -51,7 +51,7 @@
 }
 
 .pageInfo {
-  color: color.$gray-300;
+  color: #344054;
   font: font.$text-sm-regular;
 }
 

--- a/features/layout/sidebar-navigation/menu-item-button.tsx
+++ b/features/layout/sidebar-navigation/menu-item-button.tsx
@@ -7,7 +7,7 @@ type MenuItemProps = {
   className?: string;
   text: string;
   iconSrc: string;
-  onClick: () => void;
+  onClick: (event: React.MouseEvent<HTMLButtonElement>) => void;
   isCollapsed: boolean;
 };
 

--- a/features/layout/sidebar-navigation/sidebar-navigation.module.scss
+++ b/features/layout/sidebar-navigation/sidebar-navigation.module.scss
@@ -139,3 +139,7 @@
     display: flex;
   }
 }
+
+.collapseMenuItemRotate {
+  transform: rotate(180deg);
+}

--- a/features/layout/sidebar-navigation/sidebar-navigation.tsx
+++ b/features/layout/sidebar-navigation/sidebar-navigation.tsx
@@ -83,7 +83,11 @@ export function SidebarNavigation() {
               text="Support"
               iconSrc="/icons/support.svg"
               isCollapsed={isSidebarCollapsed}
-              onClick={() => alert("Support")}
+              onClick={(e) => {
+                e.preventDefault();
+                window.location.href =
+                  "mailto:support@prolog-app.com?subject=Support Request:";
+              }}
             />
             <MenuItemButton
               text="Collapse"

--- a/features/layout/sidebar-navigation/sidebar-navigation.tsx
+++ b/features/layout/sidebar-navigation/sidebar-navigation.tsx
@@ -90,7 +90,9 @@ export function SidebarNavigation() {
               iconSrc="/icons/arrow-left.svg"
               isCollapsed={isSidebarCollapsed}
               onClick={() => toggleSidebar()}
-              className={styles.collapseMenuItem}
+              className={classNames(styles.collapseMenuItem, {
+                [styles.collapseMenuItemRotate]: isSidebarCollapsed,
+              })}
             />
           </ul>
         </nav>


### PR DESCRIPTION
Sidebar Navigation: Support button should open the user’s mail app
Git Branch:

Complexity:

Skills:

fix-navigation-support-button

2

Testing

Expected behavior
Clicking the “Support” button in the sidebar navigation should open the user’s email app.

Current behavior
Clicking the support button opens an alert. There’s no further interaction or information available.



Steps to reproduce
Click on the “Support” button in the sidebar navigation.

Acceptance Criteria
The recipient should be “support@prolog-app.com”
The subject line should be pre-filled with “Support Request: “
Covered by a Cypress test